### PR TITLE
Provision profile changes to .profile instead of .bash_profile

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -27,9 +27,9 @@ else
     git clone https://github.com/rbenv/rbenv.git ~/.rbenv
     # Export the changes explicitly, because on Travis CI sourcing is impossible.
     export PATH="$HOME/.rbenv/bin:$PATH"
-    echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
+    echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.profile
     eval "$(rbenv init -)"
-    echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
+    echo 'eval "$(rbenv init -)"' >> ~/.profile
 fi
 
 # Install ruby-build.


### PR DESCRIPTION
Currently, `.bashrc` is not sourced at all since `.bash_profile` exists and does not source `.bashrc`. Normally, `.profile` sources `.bashrc`, but since provisioning creates `.bash_profile`, that gets used instead. 

This PR moves the stuff from `.bash_profile` into `.profile`